### PR TITLE
Add voicetoinstrument.com - voice to instrumental tracks AI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,3 +531,7 @@ and You!
   - **MinMo: A Multimodal Large Language Model for Seamless Voice Interaction**
   - **Author(s):** Qian Chen, Yafeng Chen, Yanni Chen, Mengzhe Chen, Yingda Chen, Chong Deng, Zhihao Du, Ruize Gao, Changfeng Gao, Zhifu Gao, Yabin Li, Xiang Lv, Jiaqing Liu, Haoneng Luo, Bin Ma, Chongjia Ni, Xian Shi, Jialong Tang, Hui Wang, Hao Wang, Wen Wang, Yuxuan Wang, Yunlan Xu, Fan Yu, Zhijie Yan, Yexin Yang, Baosong Yang, Xian Yang, Guanrou Yang, Tianyu Zhao, Qinglin Zhang, Shiliang Zhang, Nan Zhao, Pei Zhang, Chong Zhang, Jinren Zhou
   - [Paper](https://arxiv.org/abs/2501.06282) / [Other Link](https://funaudiollm.github.io/minmo)
+
+## Tools & Services
+
+- [voicetoinstrument.com](https://voicetoinstrument.com) - Convert voice to instrumental tracks using AI


### PR DESCRIPTION
Add [voicetoinstrument.com](https://voicetoinstrument.com) to Tools & Services.

voicetoinstrument.com - Convert voice to instrumental tracks using AI

Relevant to the audio AI ecosystem.