### PR TITLE
watcher: set descriptive User-Agent on arXiv requests

### DIFF
--- a/scripts/arxiv_watcher.py
+++ b/scripts/arxiv_watcher.py
@@ -90,13 +90,25 @@ def already_suggested_ids(repo: str) -> set[str]:
     return out
 
 
+USER_AGENT = (
+    "audio-ai-hub-watcher/1.0 "
+    "(+https://github.com/BinWang28/audio-ai-hub; contact: bwang28c@gmail.com)"
+)
+
+
 def _arxiv_get(url: str, max_retries: int = 4) -> str:
-    """GET arxiv URL with exponential backoff on 429 / timeout / 5xx."""
+    """GET arxiv URL with exponential backoff on 429 / timeout / 5xx.
+
+    arXiv asks API consumers to set a descriptive User-Agent including a
+    contact address; doing so substantially reduces 429 risk on shared
+    cloud runners.
+    """
     delay = 5
     last_exc = None
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     for attempt in range(1, max_retries + 1):
         try:
-            with urllib.request.urlopen(url, timeout=45) as r:
+            with urllib.request.urlopen(req, timeout=45) as r:
                 return r.read().decode("utf-8", errors="replace")
         except urllib.error.HTTPError as e:
             last_exc = e


### PR DESCRIPTION
arXiv's API guidelines ask consumers to identify themselves via a User-Agent containing a contact email. Without one, shared cloud runner IPs get throttled more aggressively.

Sets:
```
User-Agent: audio-ai-hub-watcher/1.0
  (+https://github.com/BinWang28/audio-ai-hub; contact: bwang28c@gmail.com)
```

Retry logic unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)